### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ A minimal ORM for CRUD operations. Built on top of SQLx and with its QueryBuilde
 
 This library is the one I wished I had when I built a project in Rust in production and did not want a heavy ORM.
 
+## Installation
+```sh
+cargo install tiny-orm -F postgres # sqlite or mysql
+```
+
+Or add this to your `Cargo.toml`:
+```toml
+[dependencies]
+tiny-orm = {version = "0.2.0", features = ["postgres"] } # Choose between sqlite, mysql and postgres
+```
+
 ## Principles & advantages of TinyORM
 The goals of this library are
 - To have the least amount of dependencies
@@ -31,13 +42,6 @@ Why TinyORM over another one?
 -- [convert_case](https://github.com/rutrum/convert-case)
 
 - Intuitive with smart defaults and flexible
-
-## Installation
-Add this to your `Cargo.toml`:
-```toml
-[dependencies]
-tiny-orm = {version = "0.2.0", features = ["postgres"] } # Choose between sqlite, mysql and postgres
-```
 
 ### MSRV
 MSRV has been tested with `cargo-msrv find --features sqlite`. You can learn more about [cargo-msrv on their website](https://gribnau.dev/cargo-msrv/getting-started/quick-start.html).  

--- a/tiny-orm-macros/src/attr.rs
+++ b/tiny-orm-macros/src/attr.rs
@@ -155,8 +155,7 @@ impl Parser {
                             if attr.path().is_ident(NAME_MACRO_OPERATION_ARG) {
                                 attr.parse_nested_meta(|meta| {
                                     if meta.path.is_ident("primary_key") {
-                                        let mut column =
-                                            Column::new(field_name.clone(), field.ty.clone());
+                                        let mut column = Column::new(&field_name, field.ty.clone());
 
                                         if meta.input.peek(Paren) {
                                             let content;
@@ -179,7 +178,7 @@ impl Parser {
 
                         // Default fallbacks
                         if field_name == "id" && primary_key.is_none() {
-                            primary_key = Some(Column::new(field_name.clone(), field.ty.clone()));
+                            primary_key = Some(Column::new(&field_name, field.ty.clone()));
                         }
 
                         field_names.push(field_name);
@@ -220,7 +219,7 @@ mod tests {
 
         #[test]
         fn test_set_auto_increment() {
-            let mut column = Column::new("col_name".to_string(), parse_quote!(i32));
+            let mut column = Column::new("col_name", parse_quote!(i32));
             assert!(!column.auto_increment);
             column.set_auto_increment();
             assert!(column.auto_increment);
@@ -542,10 +541,7 @@ mod tests {
             };
 
             let (primary_key, field_names) = Parser::parse_fields_macro_arguments(input.data);
-            assert_eq!(
-                primary_key,
-                Some(Column::new("id".to_string(), parse_quote!(i64)))
-            );
+            assert_eq!(primary_key, Some(Column::new("id", parse_quote!(i64))));
             assert_eq!(
                 field_names,
                 vec![
@@ -585,7 +581,7 @@ mod tests {
             let (primary_key, field_names) = Parser::parse_fields_macro_arguments(input.data);
             assert_eq!(
                 primary_key,
-                Some(Column::new("custom_key".to_string(), parse_quote!(u32)))
+                Some(Column::new("custom_key", parse_quote!(u32)))
             );
             assert_eq!(
                 field_names,
@@ -611,7 +607,7 @@ mod tests {
             };
 
             let (primary_key, _) = Parser::parse_fields_macro_arguments(input.data);
-            let mut pk = Column::new("custom_key".to_string(), parse_quote!(u32));
+            let mut pk = Column::new("custom_key", parse_quote!(u32));
             pk.set_auto_increment();
             assert_eq!(primary_key, Some(pk));
         }
@@ -634,7 +630,7 @@ mod tests {
             let (primary_key, field_names) = Parser::parse_fields_macro_arguments(input.data);
             assert_eq!(
                 primary_key,
-                Some(Column::new("custom_key".to_string(), parse_quote!(u32)))
+                Some(Column::new("custom_key", parse_quote!(u32)))
             );
             assert_eq!(
                 field_names,
@@ -666,7 +662,7 @@ mod tests {
             };
 
             let (primary_key, _) = Parser::parse_fields_macro_arguments(input.data);
-            let mut pk = Column::new("custom_key".to_string(), parse_quote!(u32));
+            let mut pk = Column::new("custom_key", parse_quote!(u32));
             pk.set_auto_increment();
             assert_eq!(primary_key, Some(pk));
         }
@@ -697,7 +693,7 @@ mod tests {
                 result,
                 Attr {
                     parsed_struct,
-                    primary_key: Some(Column::new("id".to_string(), parse_quote!(i64))),
+                    primary_key: Some(Column::new("id", parse_quote!(i64))),
                     field_names: vec![
                         "id".to_string(),
                         "created_at".to_string(),
@@ -732,7 +728,7 @@ mod tests {
                 result,
                 Attr {
                     parsed_struct,
-                    primary_key: Some(Column::new("custom_pk".to_string(), parse_quote!(i64))),
+                    primary_key: Some(Column::new("custom_pk", parse_quote!(i64))),
                     field_names: vec![
                         "custom_pk".to_string(),
                         "custom_created_at".to_string(),

--- a/tiny-orm-macros/src/attr.rs
+++ b/tiny-orm-macros/src/attr.rs
@@ -4,7 +4,7 @@ use syn::{
     Expr, ExprLit, Fields, Ident, Lit, Meta, Token,
 };
 
-use crate::types::{Column, FieldNames, Operation, Operations, ParsedStruct, PrimaryKey};
+use crate::types::{Column, Operation, Operations, ParsedStruct, PrimaryKey};
 
 const NAME_MACRO_OPERATION_ARG: &str = "tiny_orm";
 
@@ -12,7 +12,7 @@ const NAME_MACRO_OPERATION_ARG: &str = "tiny_orm";
 pub struct Attr {
     pub parsed_struct: ParsedStruct,
     pub primary_key: Option<PrimaryKey>,
-    pub field_names: FieldNames,
+    pub columns: Vec<Column>,
     pub operations: Operations,
 }
 
@@ -21,12 +21,12 @@ impl Attr {
         let struct_name = input.ident;
         let (parsed_struct, operations) =
             Parser::parse_struct_macro_arguments(&struct_name, &input.attrs);
-        let (primary_key, field_names) = Parser::parse_fields_macro_arguments(input.data);
+        let (primary_key, columns) = Parser::parse_fields_macro_arguments(input.data);
 
         Attr {
             parsed_struct,
             primary_key,
-            field_names,
+            columns,
             operations,
         }
     }
@@ -137,25 +137,28 @@ impl Parser {
         (parsed_struct, operations)
     }
 
-    fn parse_fields_macro_arguments(data: Data) -> (Option<PrimaryKey>, FieldNames) {
+    fn parse_fields_macro_arguments(data: Data) -> (Option<PrimaryKey>, Vec<Column>) {
         let mut primary_key: Option<PrimaryKey> = None;
-        let mut field_names = Vec::new();
+        let mut columns = Vec::new();
 
         match data {
             Data::Struct(data_struct) => match &data_struct.fields {
                 Fields::Named(fields) => {
                     for field in fields.named.iter() {
-                        let field_name = field
-                            .ident
-                            .as_ref()
-                            .expect("Field ident to be something")
-                            .to_string();
+                        let mut column = Column::new(
+                            &field
+                                .ident
+                                .as_ref()
+                                .expect("Field ident is expected to get its name")
+                                .to_string(),
+                            field.ty.clone(),
+                        );
 
                         for attr in &field.attrs {
                             if attr.path().is_ident(NAME_MACRO_OPERATION_ARG) {
                                 attr.parse_nested_meta(|meta| {
                                     if meta.path.is_ident("primary_key") {
-                                        let mut column = Column::new(&field_name, field.ty.clone());
+                                        column.set_primary_key();
 
                                         if meta.input.peek(Paren) {
                                             let content;
@@ -168,7 +171,7 @@ impl Parser {
                                                 }
                                             }
                                         }
-                                        primary_key = Some(column);
+                                        primary_key = Some(column.clone());
                                     }
                                     Ok(())
                                 })
@@ -177,18 +180,19 @@ impl Parser {
                         }
 
                         // Default fallbacks
-                        if field_name == "id" && primary_key.is_none() {
-                            primary_key = Some(Column::new(&field_name, field.ty.clone()));
+                        if &column.name == "id" && primary_key.is_none() {
+                            column.set_primary_key();
+                            primary_key = Some(column.clone());
                         }
 
-                        field_names.push(field_name);
+                        columns.push(column);
                     }
                 }
                 _ => panic!("Only named fields are supported"),
             },
             _ => panic!("Only structs are supported"),
         };
-        (primary_key, field_names)
+        (primary_key, columns)
     }
 
     fn get_operations(
@@ -224,14 +228,18 @@ mod tests {
             column.set_auto_increment();
             assert!(column.auto_increment);
         }
+
+        #[test]
+        fn test_set_primary_key() {
+            let mut column = Column::new("col_name", parse_quote!(i32));
+            assert!(!column.primary_key);
+            column.set_primary_key();
+            assert!(column.primary_key);
+        }
     }
 
     mod operation_tests {
         use super::{Operation, Parser};
-
-        // fn struct_name() {
-        //     TableName
-        // }
 
         #[test]
         fn test_get_them_all_by_default() {
@@ -541,14 +549,16 @@ mod tests {
             };
 
             let (primary_key, field_names) = Parser::parse_fields_macro_arguments(input.data);
-            assert_eq!(primary_key, Some(Column::new("id", parse_quote!(i64))));
+            let mut expected_pk = Column::new("id", parse_quote!(i64));
+            expected_pk.set_primary_key();
+            assert_eq!(primary_key, Some(expected_pk.clone()));
             assert_eq!(
                 field_names,
                 vec![
-                    "id".to_string(),
-                    "created_at".to_string(),
-                    "updated_at".to_string(),
-                    "last_name".to_string()
+                    expected_pk,
+                    Column::new("created_at", parse_quote!(DateTime<Utc>)),
+                    Column::new("updated_at", parse_quote!(DateTime<Utc>)),
+                    Column::new("last_name", parse_quote!(String))
                 ]
             );
         }
@@ -563,7 +573,10 @@ mod tests {
 
             let (primary_key, field_names) = Parser::parse_fields_macro_arguments(input.data);
             assert_eq!(primary_key, None);
-            assert_eq!(field_names, vec!["last_name".to_string()]);
+            assert_eq!(
+                field_names,
+                vec![Column::new("last_name", parse_quote!(String))]
+            );
         }
 
         #[test]
@@ -579,17 +592,16 @@ mod tests {
             };
 
             let (primary_key, field_names) = Parser::parse_fields_macro_arguments(input.data);
-            assert_eq!(
-                primary_key,
-                Some(Column::new("custom_key", parse_quote!(u32)))
-            );
+            let mut expected_pk = Column::new("custom_key", parse_quote!(u32));
+            expected_pk.set_primary_key();
+            assert_eq!(primary_key, Some(expected_pk.clone()));
             assert_eq!(
                 field_names,
                 vec![
-                    "custom_key".to_string(),
-                    "inserted_at".to_string(),
-                    "something_at".to_string(),
-                    "last_name".to_string()
+                    expected_pk,
+                    Column::new("inserted_at", parse_quote!(DateTime<Utc>)),
+                    Column::new("something_at", parse_quote!(DateTime<Utc>)),
+                    Column::new("last_name", parse_quote!(String))
                 ]
             );
         }
@@ -608,6 +620,7 @@ mod tests {
 
             let (primary_key, _) = Parser::parse_fields_macro_arguments(input.data);
             let mut pk = Column::new("custom_key", parse_quote!(u32));
+            pk.set_primary_key();
             pk.set_auto_increment();
             assert_eq!(primary_key, Some(pk));
         }
@@ -628,20 +641,19 @@ mod tests {
             };
 
             let (primary_key, field_names) = Parser::parse_fields_macro_arguments(input.data);
-            assert_eq!(
-                primary_key,
-                Some(Column::new("custom_key", parse_quote!(u32)))
-            );
+            let mut expect_pk = Column::new("custom_key", parse_quote!(u32));
+            expect_pk.set_primary_key();
+            assert_eq!(primary_key, Some(expect_pk.clone()));
             assert_eq!(
                 field_names,
                 vec![
-                    "custom_key".to_string(),
-                    "inserted_at".to_string(),
-                    "something_at".to_string(),
-                    "id".to_string(),
-                    "created_at".to_string(),
-                    "updated_at".to_string(),
-                    "last_name".to_string()
+                    expect_pk,
+                    Column::new("inserted_at", parse_quote!(DateTime<Utc>)),
+                    Column::new("something_at", parse_quote!(DateTime<Utc>)),
+                    Column::new("id", parse_quote!(u32)),
+                    Column::new("created_at", parse_quote!(DateTime<Utc>)),
+                    Column::new("updated_at", parse_quote!(DateTime<Utc>)),
+                    Column::new("last_name", parse_quote!(String))
                 ]
             );
         }
@@ -663,6 +675,7 @@ mod tests {
 
             let (primary_key, _) = Parser::parse_fields_macro_arguments(input.data);
             let mut pk = Column::new("custom_key", parse_quote!(u32));
+            pk.set_primary_key();
             pk.set_auto_increment();
             assert_eq!(primary_key, Some(pk));
         }
@@ -689,16 +702,18 @@ mod tests {
 
             let result = Attr::parse(input);
             let parsed_struct = ParsedStruct::new(&format_ident!("Contact"), None, None);
+            let mut primary_key = Column::new("id", parse_quote!(i64));
+            primary_key.set_primary_key();
             assert_eq!(
                 result,
                 Attr {
                     parsed_struct,
-                    primary_key: Some(Column::new("id", parse_quote!(i64))),
-                    field_names: vec![
-                        "id".to_string(),
-                        "created_at".to_string(),
-                        "updated_at".to_string(),
-                        "last_name".to_string()
+                    primary_key: Some(primary_key.clone()),
+                    columns: vec![
+                        primary_key,
+                        Column::new("created_at", parse_quote!(DateTime<Utc>)),
+                        Column::new("updated_at", parse_quote!(DateTime<Utc>)),
+                        Column::new("last_name", parse_quote!(String))
                     ],
                     operations: vec![Operation::Get, Operation::List, Operation::Delete],
                 }
@@ -717,6 +732,8 @@ mod tests {
                     last_name: String,
                 }
             };
+            let mut primary_key = Column::new("custom_pk", parse_quote!(i64));
+            primary_key.set_primary_key();
 
             let result = Attr::parse(input);
             let parsed_struct = ParsedStruct::new(
@@ -728,13 +745,14 @@ mod tests {
                 result,
                 Attr {
                     parsed_struct,
-                    primary_key: Some(Column::new("custom_pk", parse_quote!(i64))),
-                    field_names: vec![
-                        "custom_pk".to_string(),
-                        "custom_created_at".to_string(),
-                        "custom_updated_at".to_string(),
-                        "last_name".to_string()
+                    primary_key: Some(primary_key.clone()),
+                    columns: vec![
+                        primary_key,
+                        Column::new("custom_created_at", parse_quote!(DateTime<Utc>)),
+                        Column::new("custom_updated_at", parse_quote!(DateTime<Utc>)),
+                        Column::new("last_name", parse_quote!(String))
                     ],
+
                     operations: vec![Operation::Create],
                 }
             );

--- a/tiny-orm-macros/src/quotes.rs
+++ b/tiny-orm-macros/src/quotes.rs
@@ -343,7 +343,7 @@ mod tests {
         use super::*;
 
         fn input(auto_increment: bool) -> Attr {
-            let mut primary_key = Column::new("id".to_string(), parse_quote!(i64));
+            let mut primary_key = Column::new("id", parse_quote!(i64));
             if auto_increment {
                 primary_key.set_auto_increment();
             };
@@ -712,7 +712,7 @@ mod tests {
             let parsed_struct = ParsedStruct::new(&format_ident!("UpdateContact"), None, None);
             let input = Attr {
                 parsed_struct,
-                primary_key: Some(Column::new("custom_id".to_string(), parse_quote!(i64))),
+                primary_key: Some(Column::new("custom_id", parse_quote!(i64))),
                 field_names: vec!["custom_id".to_string(), "first_name".to_string()],
                 operations: vec![Operation::Update],
             };
@@ -761,7 +761,7 @@ mod tests {
             let parsed_struct = ParsedStruct::new(&format_ident!("UpdateContact"), None, None);
             let input = Attr {
                 parsed_struct,
-                primary_key: Some(Column::new("custom_id".to_string(), parse_quote!(i64))),
+                primary_key: Some(Column::new("custom_id", parse_quote!(i64))),
                 field_names: vec!["custom_id".to_string(), "first_name".to_string()],
                 operations: vec![Operation::Update],
             };

--- a/tiny-orm-macros/src/quotes.rs
+++ b/tiny-orm-macros/src/quotes.rs
@@ -181,7 +181,12 @@ pub fn create_fn(attr: &Attr) -> proc_macro2::TokenStream {
     let returning_statement = return_type.clone().returning_statement();
     let query_builder_execution = return_type.query_builder_execution();
 
-    let field_iter = attr.field_names.iter().map(|f| format_ident!("{}", f));
+    let field_iter = attr
+        .columns
+        .clone()
+        .into_iter()
+        .map(|c| c.name)
+        .map(|f| format_ident!("{}", f));
 
     let field_idents: Vec<syn::Ident> = match attr.primary_key {
         None
@@ -242,10 +247,11 @@ pub fn update_fn(attr: &Attr) -> proc_macro2::TokenStream {
         None => panic!("No primary key field found"),
     };
     let update_fields = attr
-        .field_names
+        .columns
         .clone()
         .into_iter()
-        .filter(|f| f != pk_name)
+        .filter(|c| !c.primary_key)
+        .map(|c| c.name)
         .collect::<Vec<_>>();
 
     let update_field_idents: Vec<syn::Ident> = update_fields
@@ -344,6 +350,7 @@ mod tests {
 
         fn input(auto_increment: bool) -> Attr {
             let mut primary_key = Column::new("id", parse_quote!(i64));
+            primary_key.set_primary_key();
             if auto_increment {
                 primary_key.set_auto_increment();
             };
@@ -354,12 +361,12 @@ mod tests {
             );
             Attr {
                 parsed_struct,
-                primary_key: Some(primary_key),
-                field_names: vec![
-                    "id".to_string(),
-                    "created_at".to_string(),
-                    "updated_at".to_string(),
-                    "last_name".to_string(),
+                primary_key: Some(primary_key.clone()),
+                columns: vec![
+                    primary_key,
+                    Column::new("created_at", parse_quote!(DateTime<Utc>)),
+                    Column::new("updated_at", parse_quote!(DateTime<Utc>)),
+                    Column::new("last_name", parse_quote!(String)),
                 ],
                 operations: Operation::all(),
             }
@@ -643,15 +650,17 @@ mod tests {
         #[cfg(not(feature = "mysql"))]
         #[test]
         fn test_custom_output_create() {
+            use syn::parse_quote;
+
             let db_ident = db_ident();
             let parsed_struct = ParsedStruct::new(&format_ident!("NewContact"), None, None);
             let input = Attr {
                 parsed_struct,
                 primary_key: None,
-                field_names: vec![
-                    "first_name".to_string(),
-                    "last_name".to_string(),
-                    "email".to_string(),
+                columns: vec![
+                    Column::new("first_name", parse_quote!(String)),
+                    Column::new("last_name", parse_quote!(String)),
+                    Column::new("email", parse_quote!(String)),
                 ],
                 operations: vec![Operation::Create],
             };
@@ -693,10 +702,10 @@ mod tests {
             let input = Attr {
                 parsed_struct,
                 primary_key: None,
-                field_names: vec![
-                    "first_name".to_string(),
-                    "last_name".to_string(),
-                    "email".to_string(),
+                columns: vec![
+                    Column::new("first_name", parse_quote!(String)),
+                    Column::new("last_name", parse_quote!(String)),
+                    Column::new("email", parse_quote!(String)),
                 ],
                 operations: vec![Operation::Create],
             };
@@ -710,10 +719,13 @@ mod tests {
             use syn::parse_quote;
             let db_ident = db_ident();
             let parsed_struct = ParsedStruct::new(&format_ident!("UpdateContact"), None, None);
+            let mut primary_key = Column::new("custom_id", parse_quote!(i64));
+            primary_key.set_primary_key();
+
             let input = Attr {
                 parsed_struct,
-                primary_key: Some(Column::new("custom_id", parse_quote!(i64))),
-                field_names: vec!["custom_id".to_string(), "first_name".to_string()],
+                primary_key: Some(primary_key.clone()),
+                columns: vec![primary_key, Column::new("first_name", parse_quote!(String))],
                 operations: vec![Operation::Update],
             };
 
@@ -759,10 +771,13 @@ mod tests {
         fn test_custom_output_update() {
             use syn::parse_quote;
             let parsed_struct = ParsedStruct::new(&format_ident!("UpdateContact"), None, None);
+            let mut primary_key = Column::new("custom_id", parse_quote!(i64));
+            primary_key.set_primary_key();
+
             let input = Attr {
                 parsed_struct,
-                primary_key: Some(Column::new("custom_id", parse_quote!(i64))),
-                field_names: vec!["custom_id".to_string(), "first_name".to_string()],
+                primary_key: Some(primary_key.clone()),
+                columns: vec![primary_key, Column::new("first_name", parse_quote!(String))],
                 operations: vec![Operation::Update],
             };
 

--- a/tiny-orm-macros/src/types.rs
+++ b/tiny-orm-macros/src/types.rs
@@ -115,6 +115,7 @@ pub struct Column {
     pub ident: Ident,
     pub _type: Type,
     pub auto_increment: bool,
+    pub primary_key: bool,
 }
 impl Column {
     pub fn new(name: &str, _type: Type) -> Self {
@@ -123,10 +124,14 @@ impl Column {
             ident: format_ident!("{}", name),
             _type,
             auto_increment: false,
+            primary_key: false,
         }
     }
     pub fn set_auto_increment(&mut self) {
         self.auto_increment = true;
+    }
+    pub fn set_primary_key(&mut self) {
+        self.primary_key = true;
     }
 }
 
@@ -147,7 +152,6 @@ impl fmt::Display for TableName {
 pub type StructName = Ident;
 pub type PrimaryKey = Column;
 pub type ReturnObject = Ident;
-pub type FieldNames = Vec<String>;
 pub type Operations = Vec<Operation>;
 
 #[cfg(test)]

--- a/tiny-orm-macros/src/types.rs
+++ b/tiny-orm-macros/src/types.rs
@@ -17,11 +17,11 @@ impl StructType {
             StructType::Generic => vec![Operation::Get, Operation::List, Operation::Delete],
         }
     }
-    pub fn remove_prefix(&self, input: String) -> String {
+    pub fn remove_prefix(&self, input: &str) -> String {
         match self {
             StructType::Create => input.replace("New", ""),
             StructType::Update => input.replace("Update", ""),
-            StructType::Generic => input,
+            StructType::Generic => input.to_string(),
         }
     }
 }
@@ -55,13 +55,13 @@ impl ParsedStruct {
 
         let table_name = match table_name {
             Some(value) => value,
-            None => struct_type.remove_prefix(name.clone()),
+            None => struct_type.remove_prefix(&name),
         };
 
         let return_object = match (return_object, &struct_type) {
             (Some(value), _) => value,
             (None, &StructType::Generic) => format_ident!("Self"),
-            (None, _) => format_ident!("{}", struct_type.remove_prefix(name)),
+            (None, _) => format_ident!("{}", struct_type.remove_prefix(&name)),
         };
 
         Self {

--- a/tiny-orm-macros/src/types.rs
+++ b/tiny-orm-macros/src/types.rs
@@ -117,9 +117,9 @@ pub struct Column {
     pub auto_increment: bool,
 }
 impl Column {
-    pub fn new(name: String, _type: Type) -> Self {
+    pub fn new(name: &str, _type: Type) -> Self {
         Self {
-            name: name.clone(),
+            name: name.to_string(),
             ident: format_ident!("{}", name),
             _type,
             auto_increment: false,
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_set_auto_increment() {
-        let mut column = Column::new("col_name".to_string(), parse_quote!(i32));
+        let mut column = Column::new("col_name", parse_quote!(i32));
         assert!(!column.auto_increment);
         column.set_auto_increment();
         assert!(column.auto_increment);

--- a/tiny-orm-macros/src/types.rs
+++ b/tiny-orm-macros/src/types.rs
@@ -66,7 +66,7 @@ impl ParsedStruct {
 
         Self {
             name: struct_name.clone(),
-            table_name: TableName::new(table_name),
+            table_name: TableName::new(&table_name),
             struct_type,
             return_object,
         }
@@ -133,7 +133,7 @@ impl Column {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableName(pub String);
 impl TableName {
-    pub fn new(input: String) -> Self {
+    pub fn new(input: &str) -> Self {
         Self(input.to_case(Case::Snake))
     }
 }


### PR DESCRIPTION
# What
- Cleanup the input argument to use &str instead of String when relevant
- Get `columns` in the Attr struct which hold Vec<Column> rather than just captured to field_names as Vec<String>