### PR TITLE
Introduce tiny-orm-core to implement SetOption

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Publish to crates.io
         run: |
-          cargo publish --features sqlite --dry-run --package tiny-orm-macros
-          cargo publish --features sqlite --dry-run --package tiny-orm
+          cargo publish --package tiny-orm-core
+          cargo publish --package tiny-orm-macros --features sqlite
+          cargo publish --package tiny-orm --features sqlite
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,9 +1486,18 @@ name = "tiny-orm"
 version = "0.2.0"
 dependencies = [
  "sqlx",
+ "tiny-orm-core",
  "tiny-orm-macros",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "tiny-orm-core"
+version = "0.2.0"
+dependencies = [
+ "sqlx",
+ "tokio-test",
 ]
 
 [[package]]
@@ -1478,6 +1509,7 @@ dependencies = [
  "quote",
  "sqlx",
  "syn",
+ "tiny-orm-core",
  "tokio",
  "uuid",
 ]
@@ -1533,6 +1565,19 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,11 @@ include = [
 ]
 
 [workspace]
-members = ["tiny-orm-macros"]
+members = ["tiny-orm-core", "tiny-orm-macros"]
 
 [dependencies]
 tiny-orm-macros = { version = "0.2.0", path = "./tiny-orm-macros", features = [] }
+tiny-orm-core = { version = "0.2.0", path = "./tiny-orm-core", features = [] }
 sqlx = { version = ">=0.7, <1.0", default-features = false }
 
 [features]

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,12 @@ define update_version
 	@NEXT_VERSION="$(1)" && \
 	CURRENT_VERSION="$(VERSION)" && \
 	perl -pi -e 's/version = "'"$$CURRENT_VERSION"'"/version = "'"$$NEXT_VERSION"'"/' Cargo.toml && \
+	perl -pi -e 's/tiny-orm-macros = \{ version = "'"$$CURRENT_VERSION"'"/tiny-orm-core = { version = "'"$$NEXT_VERSION"'"/' Cargo.toml && \
 	perl -pi -e 's/tiny-orm-macros = \{ version = "'"$$CURRENT_VERSION"'"/tiny-orm-macros = { version = "'"$$NEXT_VERSION"'"/' Cargo.toml && \
+	perl -pi -e 's/version = "'"$$CURRENT_VERSION"'"/version = "'"$$NEXT_VERSION"'"/' tiny-orm-core/Cargo.toml && \
 	perl -pi -e 's/version = "'"$$CURRENT_VERSION"'"/version = "'"$$NEXT_VERSION"'"/' tiny-orm-macros/Cargo.toml && \
-		perl -pi -e 's/tiny-orm = \{version = "'"$$CURRENT_VERSION"'"/tiny-orm = {version = "'"$$NEXT_VERSION"'"/' README.md && \
+	perl -pi -e 's/tiny-orm-macros = \{ version = "'"$$CURRENT_VERSION"'"/tiny-orm-core = { version = "'"$$NEXT_VERSION"'"/' tiny-orm-macros/Cargo.toml && \
+	perl -pi -e 's/tiny-orm = \{version = "'"$$CURRENT_VERSION"'"/tiny-orm = {version = "'"$$NEXT_VERSION"'"/' README.md && \
 	perl -pi -e 's/tiny-orm\/'"$$CURRENT_VERSION"'\/tiny_orm/tiny-orm\/'"$$NEXT_VERSION"'\/tiny_orm/' README.md
 
 	echo "Version updated to $$NEXT_VERSION from $$CURRENT_VERSION in all files"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,4 +164,5 @@
 //! }
 //! ```
 
+pub use tiny_orm_core::*;
 pub use tiny_orm_macros::*;

--- a/tiny-orm-core/Cargo.toml
+++ b/tiny-orm-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tiny-orm-core"
+version = "0.2.0"
+edition = "2021"
+rust-version = "1.74.1"
+authors = ["Matt Delacour - mdelacour.com"]
+description = "Struct and Trait avaiable for Tiny ORM. Not intended to be used directly."
+license = "MIT"
+repository = "https://github.com/MattDelac/tiny_orm"
+
+[dependencies]
+sqlx = { version = ">=0.7, <1.0", default-features = false }
+
+[dev-dependencies]
+tokio-test = "0.4.4"

--- a/tiny-orm-core/src/lib.rs
+++ b/tiny-orm-core/src/lib.rs
@@ -1,0 +1,209 @@
+use sqlx::decode::Decode;
+use sqlx::error::BoxDynError;
+use sqlx::{Database, Type, ValueRef};
+
+/// tiny_orm::SetOption is an enum that behave similarly to `Option` in the sense that there are only two variants.
+/// The goal is to easily differentiate between an Option type and a SetOption type.
+/// So that it is possible to have a struct like the following
+/// ```rust
+/// # use tiny_orm_core::SetOption;
+///
+/// struct Todo {
+///     id: SetOption<i64>,
+///     description: SetOption<Option<String>>,
+/// }
+/// ```
+///
+/// When the variant will be `SetOption::NotSet`, then tiny ORM will automatically skip the field during "write" operations
+/// like `create()` or `update()`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SetOption<T> {
+    Set(T),
+    #[default]
+    NotSet,
+}
+
+/// Implement `From` for `SetOption` to allow for easy conversion from a value to a `SetOption`.
+/// ```rust
+/// # use tiny_orm_core::SetOption;
+/// let set_option: SetOption<i32> = 1.into();
+/// assert_eq!(set_option, SetOption::Set(1));
+/// ```
+impl<T> From<T> for SetOption<T> {
+    fn from(value: T) -> Self {
+        SetOption::Set(value)
+    }
+}
+
+/// Implement `From` for `Result` to allow for easy conversion from a `SetOption` to a `Result`.
+/// This is useful when you want to handle the `NotSet` variant as an error case.
+///
+/// # Examples
+/// ```rust
+/// # use tiny_orm_core::SetOption;
+/// let set_option: SetOption<i32> = 1.into();
+/// let result: Result<i32, _> = set_option.into();
+/// assert_eq!(result, Ok(1));
+/// ```
+/// ```rust
+/// # use tiny_orm_core::SetOption;
+/// let not_set: SetOption<i32> = SetOption::NotSet;
+/// let result: Result<i32, _> = not_set.into();
+/// assert_eq!(result, Err("Cannot convert NotSet variant to value"));
+/// ```
+impl<T> From<SetOption<T>> for Result<T, &'static str> {
+    fn from(value: SetOption<T>) -> Self {
+        match value {
+            SetOption::Set(value) => Ok(value),
+            SetOption::NotSet => Err("Cannot convert NotSet variant to value"),
+        }
+    }
+}
+
+impl<T> SetOption<T> {
+    /// `inner()` is a method to get the inner value as an Option type.
+    /// This return an Option<T> type wher Some<T> is corresponds when the value
+    /// was using the `Set` variant,
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use tiny_orm_core::SetOption;
+    /// let set = SetOption::Set(1);
+    /// let inner = set.inner();
+    /// assert_eq!(inner, Some(1));
+    /// ```
+    ///
+    /// ```rust
+    /// # use tiny_orm_core::SetOption;
+    /// let not_set: SetOption<i32> = SetOption::NotSet;
+    /// let inner = not_set.inner();
+    /// assert_eq!(inner, None);
+    /// ```
+    pub fn inner(self) -> Option<T> {
+        match self {
+            SetOption::NotSet => None,
+            SetOption::Set(value) => Some(value),
+        }
+    }
+
+    /// `is_set()` returns true if the variant is `Set`
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use tiny_orm_core::SetOption;
+    /// let set = SetOption::Set(1);
+    /// assert!(set.is_set());
+    /// ```
+    ///
+    /// ```rust
+    /// # use tiny_orm_core::SetOption;
+    /// let not_set: SetOption<i32> = SetOption::NotSet;
+    /// assert!(!not_set.is_set());
+    /// ```
+    pub fn is_set(&self) -> bool {
+        match self {
+            SetOption::Set(_) => true,
+            SetOption::NotSet => false,
+        }
+    }
+
+    /// `is_not_set()` returns true if the variant is `NotSet`
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use tiny_orm_core::SetOption;
+    /// let set = SetOption::Set(1);
+    /// assert!(!set.is_not_set());
+    /// ```
+    ///
+    /// ```rust
+    /// # use tiny_orm_core::SetOption;
+    /// let not_set: SetOption<i32> = SetOption::NotSet;
+    /// assert!(not_set.is_not_set());
+    /// ```
+    pub fn is_not_set(&self) -> bool {
+        match self {
+            SetOption::Set(_) => false,
+            SetOption::NotSet => true,
+        }
+    }
+}
+
+/// Implements database decoding for SetOption<T>.
+/// This allows automatic conversion from database values to SetOption<T>.
+///
+/// # Examples
+/// ```rust
+/// # use sqlx::SqlitePool;
+/// # use tiny_orm_core::SetOption;
+/// # use sqlx::FromRow;
+/// #
+/// #[derive(FromRow)]
+/// struct TestRecord {
+///     value: SetOption<i32>,
+/// }
+///
+/// # tokio_test::block_on(async {
+/// let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+///
+/// # sqlx::query(
+/// #    "CREATE TABLE test (value INTEGER)"
+/// # ).execute(&pool).await.unwrap();
+///
+/// # sqlx::query(
+/// #    "INSERT INTO test (value) VALUES (?)"
+/// # )
+/// # .bind(42)
+/// # .execute(&pool).await.unwrap();
+///
+/// // Test with a value
+/// let record: TestRecord = sqlx::query_as("SELECT value FROM test")
+///     .fetch_one(&pool)
+///     .await
+///     .unwrap();
+///
+/// assert_eq!(record.value, SetOption::Set(42));
+///
+/// // Test NULL value
+/// # sqlx::query("DELETE FROM test").execute(&pool).await.unwrap();
+/// # sqlx::query(
+/// #    "INSERT INTO test (value) VALUES (?)"
+/// # )
+/// # .bind(None::<i32>)
+/// # .execute(&pool).await.unwrap();
+///
+/// let record: TestRecord = sqlx::query_as("SELECT value FROM test")
+///     .fetch_one(&pool)
+///     .await
+///     .unwrap();
+///
+/// assert_eq!(record.value, SetOption::NotSet);
+/// # });
+/// ```
+impl<'r, DB, T> Decode<'r, DB> for SetOption<T>
+where
+    DB: Database,
+    T: Decode<'r, DB>,
+{
+    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
+        if value.is_null() {
+            return Ok(SetOption::NotSet);
+        }
+
+        Ok(SetOption::Set(T::decode(value)?))
+    }
+}
+
+impl<DB, T> Type<DB> for SetOption<T>
+where
+    DB: Database,
+    T: Type<DB>,
+{
+    fn type_info() -> <DB as Database>::TypeInfo {
+        T::type_info()
+    }
+
+    fn compatible(ty: &<DB as Database>::TypeInfo) -> bool {
+        T::compatible(ty)
+    }
+}

--- a/tiny-orm-macros/Cargo.toml
+++ b/tiny-orm-macros/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "2.0", features = ["full", "extra-traits"] }
+tiny-orm-core = { version = "0.2.0", path = "../tiny-orm-core" }
 quote = "1.0"
 proc-macro2 = "1.0"
 convert_case = "<1.0"


### PR DESCRIPTION
# What
- Add tiny-orm-core that will contain the pub struct & trait
- Add SetOption which will be used to automatically skip some fields if they are Unset (like ActiveRecord)
- Cleanup the publish CICD and Makefile to take into account this new crate