### PR TITLE
Use set option to skip field when unset

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,9 @@ jobs:
       - name: Run tests on sqlite
         run: cargo run --example sqlite --features sqlite
 
+      - name: Run tests on sqlite-setoption
+        run: cargo run --example sqlite-setoption --features sqlite
+
       - name: Run tests on Postgres
         run: cargo run --example postgres --features postgres
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1005,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rsa"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,8 +1543,10 @@ name = "tiny-orm-macros"
 version = "0.2.0"
 dependencies = [
  "convert_case",
+ "once_cell",
  "proc-macro2",
  "quote",
+ "regex",
  "sqlx",
  "syn",
  "tiny-orm-core",

--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ impl Todo {
 
 <!-- cargo-rdme end -->
 
+#### `SetOption`
+`SetOption` is an Enum that behaves similarly to `Option`. The main difference is that Tiny ORM will automatically exclude the fields once they are `Unset`.  
+The goal is to not always push all the fields during update or create operations. This would avoid some potential data race condition if the local struct is out of date with what the database has.  
+You can check [tiny-orm-core/src/lib.rs](./tiny-orm-core/src/lib.rs) but `SetOption` implement most of the Traits needed to automatically be used with Sqlx (Encode, Decode) as well as useful methods like `.inner(), .is_set() & .is_not_set()`.  
+You can check the [`sqlite-setoption` example](./examples/sqlite-setoption/main.rs) to see it in action.
+
 ## Migrations
 ### From 0.1.* to 0.2.*
 In 0.2.0, the API was stabilized with the fact that

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Why TinyORM over another one?
 
 - Minimal set of dependencies (fast compile time)  
 -- [SQLx](https://github.com/launchbadge/sqlx)  
--- [convert_case](https://github.com/rutrum/convert-case)
+-- [convert_case](https://github.com/rutrum/convert-case)  
+-- [regex](https://crates.io/crates/regex)  
+-- [lazy_static](https://crates.io/crates/https://crates.io/crates/lazy_static)  
 
 - Intuitive with smart defaults and flexible
 
@@ -192,13 +194,13 @@ struct Todo {
 ```
 
 ```rust
-use tiny_orm::Table;
+use tiny_orm::{Table, SetOption};
 #[derive(Debug, FromRow, Table, Clone)]
 struct Todo {
     #[tiny_orm(primary_key(auto))]
     id: i64,
-    description: Option<String>,
-    done: Option<bool>
+    description: SetOption<String>,
+    done: SetOption<bool>
 }
 ```
 

--- a/examples/sqlite-setoption/README.md
+++ b/examples/sqlite-setoption/README.md
@@ -1,0 +1,7 @@
+# TODOs Example
+
+## Usage
+
+```sh
+cargo run --example sqlite-setoption --features sqlite
+```

--- a/examples/sqlite-setoption/main.rs
+++ b/examples/sqlite-setoption/main.rs
@@ -1,0 +1,74 @@
+use sqlx::{
+    migrate::Migrator,
+    types::chrono::{DateTime, Utc},
+    FromRow, SqlitePool,
+};
+use tiny_orm::{SetOption, Table};
+
+#[derive(Debug, FromRow, Table, Clone)]
+struct Todo {
+    id: i32,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    description: String,
+    done: bool,
+}
+
+#[derive(Debug, FromRow, Table, Clone)]
+struct NewTodo {
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    description: String,
+    done: bool,
+}
+
+#[derive(Debug, Default, FromRow, Table, Clone)]
+struct UpdateTodo {
+    id: i32,
+    updated_at: SetOption<DateTime<Utc>>,
+    description: SetOption<String>,
+    done: SetOption<bool>,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let m = Migrator::new(std::path::Path::new("examples/sqlite/migrations"))
+        .await
+        .unwrap();
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    let _ = m.run(&pool).await.unwrap();
+
+    let new_todo = NewTodo {
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        description: "My first item".to_string(),
+        done: false,
+    };
+
+    let todo = new_todo
+        .create(&pool)
+        .await
+        .expect("Todo item should be created");
+    println!("My first todo created {:?}", todo.id);
+
+    let first_todo = Todo::get_by_id(&pool, todo.id).await.unwrap();
+    match first_todo {
+        Some(ref item) => println!("First todo item is {:?}", item),
+        None => println!("Todo item does not exist for the id {}", todo.id),
+    }
+    let update_todo = UpdateTodo {
+        id: todo.id,
+        description: "My first item updated".to_string().into(),
+        ..Default::default()
+    };
+    update_todo
+        .update(&pool)
+        .await
+        .expect("Item should be updated");
+
+    let check_updated_item = Todo::get_by_id(&pool, todo.id).await.unwrap();
+    match check_updated_item {
+        Some(ref item) => println!("Updated item is {:?}", item),
+        None => println!("Todo item does not exist for the id {}", todo.id),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,14 +143,14 @@
 //! ```
 //!
 //! ```rust
-//! use tiny_orm::Table;
+//! use tiny_orm::{Table, SetOption};
 //! # use sqlx::FromRow;
 //! #[derive(Debug, FromRow, Table, Clone)]
 //! struct Todo {
 //!     #[tiny_orm(primary_key(auto))]
 //!     id: i64,
-//!     description: Option<String>,
-//!     done: Option<bool>
+//!     description: SetOption<String>,
+//!     done: SetOption<bool>
 //! }
 //! ```
 //!

--- a/tiny-orm-macros/Cargo.toml
+++ b/tiny-orm-macros/Cargo.toml
@@ -17,6 +17,8 @@ tiny-orm-core = { version = "0.2.0", path = "../tiny-orm-core" }
 quote = "1.0"
 proc-macro2 = "1.0"
 convert_case = "<1.0"
+regex = "< 2.0"
+once_cell = "< 2.0"
 
 [features]
 default = []


### PR DESCRIPTION
Fixes: https://github.com/MattDelac/tiny_orm/issues/23

# What
- Add the `Encode` trait from SQLx to SetOption
- Use `SetOption` to automatically skip fields during create() and update() operations
- Add tests + an example