### PR TITLE
Bump to v0.3.1

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Publish to crates.io
         run: |
-          cargo publish --package tiny-orm-core
+          cargo publish --package tiny-orm-model
           cargo publish --package tiny-orm-macros --features sqlite
           cargo publish --package tiny-orm --features sqlite
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,26 +1521,18 @@ dependencies = [
 
 [[package]]
 name = "tiny-orm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "sqlx",
- "tiny-orm-core",
  "tiny-orm-macros",
+ "tiny-orm-model",
  "tokio",
  "uuid",
 ]
 
 [[package]]
-name = "tiny-orm-core"
-version = "0.3.0"
-dependencies = [
- "sqlx",
- "tokio-test",
-]
-
-[[package]]
 name = "tiny-orm-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "convert_case",
  "once_cell",
@@ -1549,9 +1541,17 @@ dependencies = [
  "regex",
  "sqlx",
  "syn",
- "tiny-orm-core",
+ "tiny-orm-model",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "tiny-orm-model"
+version = "0.3.1"
+dependencies = [
+ "sqlx",
+ "tokio-test",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-orm"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.74.1"
 authors = ["Matt Delacour - mdelacour.com"]
@@ -21,11 +21,11 @@ include = [
 ]
 
 [workspace]
-members = ["tiny-orm-core", "tiny-orm-macros"]
+members = ["tiny-orm-model", "tiny-orm-macros"]
 
 [dependencies]
-tiny-orm-macros = { version = "0.3.0", path = "./tiny-orm-macros", features = [] }
-tiny-orm-core = { version = "0.3.0", path = "./tiny-orm-core", features = [] }
+tiny-orm-macros = { version = "0.3.1", path = "./tiny-orm-macros", features = [] }
+tiny-orm-model = { version = "0.3.1", path = "./tiny-orm-model", features = [] }
 sqlx = { version = ">=0.7, <1.0", default-features = false }
 
 [features]

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ define update_version
 	@NEXT_VERSION="$(1)" && \
 	CURRENT_VERSION="$(VERSION)" && \
 	perl -pi -e 's/version = "'"$$CURRENT_VERSION"'"/version = "'"$$NEXT_VERSION"'"/' Cargo.toml && \
-	perl -pi -e 's/tiny-orm-macros = \{ version = "'"$$CURRENT_VERSION"'"/tiny-orm-core = { version = "'"$$NEXT_VERSION"'"/' Cargo.toml && \
+	perl -pi -e 's/tiny-orm-macros = \{ version = "'"$$CURRENT_VERSION"'"/tiny-orm-model = { version = "'"$$NEXT_VERSION"'"/' Cargo.toml && \
 	perl -pi -e 's/tiny-orm-macros = \{ version = "'"$$CURRENT_VERSION"'"/tiny-orm-macros = { version = "'"$$NEXT_VERSION"'"/' Cargo.toml && \
-	perl -pi -e 's/version = "'"$$CURRENT_VERSION"'"/version = "'"$$NEXT_VERSION"'"/' tiny-orm-core/Cargo.toml && \
+	perl -pi -e 's/version = "'"$$CURRENT_VERSION"'"/version = "'"$$NEXT_VERSION"'"/' tiny-orm-model/Cargo.toml && \
 	perl -pi -e 's/version = "'"$$CURRENT_VERSION"'"/version = "'"$$NEXT_VERSION"'"/' tiny-orm-macros/Cargo.toml && \
-	perl -pi -e 's/tiny-orm-macros = \{ version = "'"$$CURRENT_VERSION"'"/tiny-orm-core = { version = "'"$$NEXT_VERSION"'"/' tiny-orm-macros/Cargo.toml && \
+	perl -pi -e 's/tiny-orm-macros = \{ version = "'"$$CURRENT_VERSION"'"/tiny-orm-model = { version = "'"$$NEXT_VERSION"'"/' tiny-orm-macros/Cargo.toml && \
 	perl -pi -e 's/tiny-orm = \{version = "'"$$CURRENT_VERSION"'"/tiny-orm = {version = "'"$$NEXT_VERSION"'"/' README.md && \
 	perl -pi -e 's/tiny-orm\/'"$$CURRENT_VERSION"'\/tiny_orm/tiny-orm\/'"$$NEXT_VERSION"'\/tiny_orm/' README.md
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cargo install tiny-orm -F postgres # sqlite or mysql
 Or add this to your `Cargo.toml`:
 ```toml
 [dependencies]
-tiny-orm = {version = "0.3.0", features = ["postgres"] } # Choose between sqlite, mysql and postgres
+tiny-orm = {version = "0.3.1", features = ["postgres"] } # Choose between sqlite, mysql and postgres
 ```
 
 ## Principles & advantages of TinyORM
@@ -219,7 +219,7 @@ impl Todo {
 #### `SetOption`
 `SetOption` is an Enum that behaves similarly to `Option`. The main difference is that Tiny ORM will automatically exclude the fields once they are `Unset`.  
 The goal is to not always push all the fields during update or create operations. This would avoid some potential data race condition if the local struct is out of date with what the database has.  
-You can check [tiny-orm-core/src/lib.rs](./tiny-orm-core/src/lib.rs) but `SetOption` implement most of the Traits needed to automatically be used with Sqlx (Encode, Decode) as well as useful methods like `.inner(), .is_set() & .is_not_set()`.  
+You can check [tiny-orm-model/src/lib.rs](./tiny-orm-model/src/lib.rs) but `SetOption` implement most of the Traits needed to automatically be used with Sqlx (Encode, Decode) as well as useful methods like `.inner(), .is_set() & .is_not_set()`.  
 You can check the [`sqlite-setoption` example](./examples/sqlite-setoption/main.rs) to see it in action.
 
 ## Migrations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,5 +164,5 @@
 //! }
 //! ```
 
-pub use tiny_orm_core::*;
 pub use tiny_orm_macros::*;
+pub use tiny_orm_model::*;

--- a/tiny-orm-macros/Cargo.toml
+++ b/tiny-orm-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-orm-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.74.1"
 authors = ["Matt Delacour - mdelacour.com"]
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "2.0", features = ["full", "extra-traits"] }
-tiny-orm-core = { version = "0.3.0", path = "../tiny-orm-core" }
+tiny-orm-model = { version = "0.3.1", path = "../tiny-orm-model" }
 quote = "1.0"
 proc-macro2 = "1.0"
 convert_case = "<1.0"

--- a/tiny-orm-model/Cargo.toml
+++ b/tiny-orm-model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "tiny-orm-core"
-version = "0.3.0"
+name = "tiny-orm-model"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.74.1"
 authors = ["Matt Delacour - mdelacour.com"]

--- a/tiny-orm-model/src/lib.rs
+++ b/tiny-orm-model/src/lib.rs
@@ -7,7 +7,7 @@ use sqlx::{Database, Encode, Type, ValueRef};
 /// The goal is to easily differentiate between an Option type and a SetOption type.
 /// So that it is possible to have a struct like the following
 /// ```rust
-/// # use tiny_orm_core::SetOption;
+/// # use tiny_orm_model::SetOption;
 ///
 /// struct Todo {
 ///     id: SetOption<i64>,
@@ -26,7 +26,7 @@ pub enum SetOption<T> {
 
 /// Implement `From` for `SetOption` to allow for easy conversion from a value to a `SetOption`.
 /// ```rust
-/// # use tiny_orm_core::SetOption;
+/// # use tiny_orm_model::SetOption;
 /// let set_option: SetOption<i32> = 1.into();
 /// assert_eq!(set_option, SetOption::Set(1));
 /// ```
@@ -41,13 +41,13 @@ impl<T> From<T> for SetOption<T> {
 ///
 /// # Examples
 /// ```rust
-/// # use tiny_orm_core::SetOption;
+/// # use tiny_orm_model::SetOption;
 /// let set_option: SetOption<i32> = 1.into();
 /// let result: Result<i32, _> = set_option.into();
 /// assert_eq!(result, Ok(1));
 /// ```
 /// ```rust
-/// # use tiny_orm_core::SetOption;
+/// # use tiny_orm_model::SetOption;
 /// let not_set: SetOption<i32> = SetOption::NotSet;
 /// let result: Result<i32, _> = not_set.into();
 /// assert_eq!(result, Err("Cannot convert NotSet variant to value"));
@@ -68,14 +68,14 @@ impl<T> SetOption<T> {
     ///
     /// # Examples
     /// ```rust
-    /// # use tiny_orm_core::SetOption;
+    /// # use tiny_orm_model::SetOption;
     /// let set = SetOption::Set(1);
     /// let inner = set.inner();
     /// assert_eq!(inner, Some(1));
     /// ```
     ///
     /// ```rust
-    /// # use tiny_orm_core::SetOption;
+    /// # use tiny_orm_model::SetOption;
     /// let not_set: SetOption<i32> = SetOption::NotSet;
     /// let inner = not_set.inner();
     /// assert_eq!(inner, None);
@@ -91,13 +91,13 @@ impl<T> SetOption<T> {
     ///
     /// # Examples
     /// ```rust
-    /// # use tiny_orm_core::SetOption;
+    /// # use tiny_orm_model::SetOption;
     /// let set = SetOption::Set(1);
     /// assert!(set.is_set());
     /// ```
     ///
     /// ```rust
-    /// # use tiny_orm_core::SetOption;
+    /// # use tiny_orm_model::SetOption;
     /// let not_set: SetOption<i32> = SetOption::NotSet;
     /// assert!(!not_set.is_set());
     /// ```
@@ -112,13 +112,13 @@ impl<T> SetOption<T> {
     ///
     /// # Examples
     /// ```rust
-    /// # use tiny_orm_core::SetOption;
+    /// # use tiny_orm_model::SetOption;
     /// let set = SetOption::Set(1);
     /// assert!(!set.is_not_set());
     /// ```
     ///
     /// ```rust
-    /// # use tiny_orm_core::SetOption;
+    /// # use tiny_orm_model::SetOption;
     /// let not_set: SetOption<i32> = SetOption::NotSet;
     /// assert!(not_set.is_not_set());
     /// ```
@@ -136,7 +136,7 @@ impl<T> SetOption<T> {
 /// # Examples
 /// ```rust
 /// # use sqlx::SqlitePool;
-/// # use tiny_orm_core::SetOption;
+/// # use tiny_orm_model::SetOption;
 /// # use sqlx::FromRow;
 /// #
 /// #[derive(FromRow)]
@@ -215,7 +215,7 @@ where
 /// # Examples
 /// ```rust
 /// # use sqlx::SqlitePool;
-/// # use tiny_orm_core::SetOption;
+/// # use tiny_orm_model::SetOption;
 /// # use sqlx::FromRow;
 /// #
 /// #[derive(FromRow)]


### PR DESCRIPTION
Rename tiny-orm-core to tiny-orm-model since the former is already taken