### PR TITLE
docs(README): The table name being a snake_case version

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The Table macro comes with a few options to give flexibility to the user
 
 ##### At the Struct level
 - **table_name**: The name of the table in the database.
-  Default being a lower_case version of the Struct name. So `MyStruct` would have `my_struct` as a default `table_name`.
+  Default being a snake_case version of the Struct name. So `MyStruct` would have `my_struct` as a default `table_name`.
 - **only**: The methods that will only be available to that struct. Multiple values are comma separated.
   Default is dependent on the struct name (see below).
 - **exclude**: The methods that will be excluded for that struct. Multiple values are comma separated

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! ### At the Struct level
 //! - **table_name**: The name of the table in the database.
-//!   Default being a lower_case version of the Struct name. So `MyStruct` would have `my_struct` as a default `table_name`.
+//!   Default being a snake_case version of the Struct name. So `MyStruct` would have `my_struct` as a default `table_name`.
 //! - **only**: The methods that will only be available to that struct. Multiple values are comma separated.
 //!   Default is dependent on the struct name (see below).
 //! - **exclude**: The methods that will be excluded for that struct. Multiple values are comma separated


### PR DESCRIPTION
The table name is the snake_case version of the struct, not lowercase

refs: https://github.com/MattDelac/tiny_orm/blob/f14ca5ebc7bdb4ad45280a59360b8d21b8661375/tiny-orm-macros/src/types.rs#L150